### PR TITLE
Drop unused Pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
   matrix:
     
     - CONDA_PY=27
-    - CONDA_PY=35
-    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "d2f0v8B3i2GG7c+wgAOTHtWcS+if84qWil0r/40TwrKDyKunGwN0WtteocjwzLfW5a8JqhsopYZxBzDaxm+tT7tLp5I1fqSEYHHXVD49AG+E2iFblcze7NK4l4HqlypRHUgNGDVzFL/CnOwtCmWK3qeYEDjebjGULl37Rz+0I4pkN1IK/SNJ8tQhcTLDykAJpEey4zjhIoTDnKiAHvBXn1D3pMEp5s7HBlc0n0S/u4EuZGiIhmkqWlivgULt6oE5BmZIWheTide3Us1fItylaIuRXZcv+eALCgJZs0ytwb+IB8kFJvoKduvvKa1+BV2TbfuP/8GwOW9vcYWiepqRg3Yx72Hw0OmzUDIIG+KFQ/6K0TQSZGZV8loPDjXRJOkH99NLMj+7b9iak+DQ086gGaUVXQsU7hO+KcnlV+CXJJDHpTg+4ow+yhO6OuifA020mhxtA4kSLY/vd860lSIcOPoMzNAWuIijJClZwuZdX/dspoLjR9kV2EMYlzQGs+jW0glEhmOW11GmpHgqKTDPfiYkS9ZpG6DnRXvUAPHAhbAwCzKiZ96FwlqsfZenGQ4BjupSM48+iPJs+hMUH32tOIY9IlflHQQg2n8QbGQpAxe/lhpjZ1nWB8GBi+IwlJrH+r3uu5BEj5KKSt8ZnnMhJlm5GcU0FbamHTgwxdrwcyE="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,21 +43,9 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
+# Embarking on 1 case(s).
     set -x
     export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [unix and py3k]
 
 requirements:
   build:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/yasm-feedstock/issues/7

Drops all Pythons except Python 2.7 as they are only used for building.