### PR TITLE
Build from source on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,14 @@ environment:
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,1 +1,19 @@
-copy yasm.exe %LIBRARY_BIN%\yasm.exe
+mkdir build
+if errorlevel 1 exit 1
+
+cd build
+if errorlevel 1 exit 1
+
+cmake -G "NMake Makefiles" ^
+         -DCMAKE_BUILD_TYPE:STRING=RELEASE ^
+         -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+         -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
+         -DBUILD_STATIC_LIBS:BOOL=ON ^
+         %SRC_DIR%
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,10 +29,10 @@ test:
 
   commands:
     - test -f ${PREFIX}/lib/libyasm.a       # [unix]
-    - vsyasm --help                         # [unix]
-    - yasm --help                           # [unix]
-    - ytasm /h                              # [unix]
-    - yasm --version                        # [win]
+    - vsyasm --help
+    - yasm --help
+    - ytasm /h
+    - yasm --version
 
 about:
   home: http://www.tortall.net/projects/yasm/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,30 +5,34 @@ package:
   version: {{ version }}
 
 source:
-  fn: yasm-{{ version }}.tar.gz                                                    # [unix]
-  url: http://www.tortall.net/projects/yasm/releases/yasm-{{ version }}.tar.gz     # [unix]
-  sha1: b7574e9f0826bedef975d64d3825f75fbaeef55e                                   # [unix]
-  fn: yasm.exe                                                                     # [win]
-  url: http://www.tortall.net/projects/yasm/releases/yasm-{{ version }}-win32.exe  # [win32]
-  sha1: 8374a6a1d6a240a3baa771ffd61b3bc096ccd11f                                   # [win32]
-  url: http://www.tortall.net/projects/yasm/releases/yasm-{{ version }}-win64.exe  # [win64]
-  sha1: f7872c6db3b4d93fd5a51717364d438108473149                                   # [win64]
+  fn: yasm-{{ version }}.tar.gz
+  url: http://www.tortall.net/projects/yasm/releases/yasm-{{ version }}.tar.gz
+  sha1: b7574e9f0826bedef975d64d3825f75fbaeef55e
 
 build:
   number: 0
-  skip: true  # [unix and py3k]
+  skip: true  # [(unix and py3k) or (win and py36)]
+  features:
+    - vc9     # [win and py27]
+    - vc10    # [win and py34]
+    - vc14    # [win and py35]
+    - vc14    # [win and py36]
 
 requirements:
   build:
-    - python  # [unix]
+    - cmake   # [win]
+    - python
 
 test:
+  requires:
+    - python {{ environ['PY_VER'] + '*' }}  # [win]
+
   commands:
-    - test -f ${PREFIX}/lib/libyasm.a      # [unix]
-    - vsyasm --help                        # [unix]
-    - yasm --help                          # [unix]
-    - ytasm /h                             # [unix]
-    - yasm --version                       # [win]
+    - test -f ${PREFIX}/lib/libyasm.a       # [unix]
+    - vsyasm --help                         # [unix]
+    - yasm --help                           # [unix]
+    - ytasm /h                              # [unix]
+    - yasm --version                        # [win]
 
 about:
   home: http://www.tortall.net/projects/yasm/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,9 @@ test:
     - python {{ environ['PY_VER'] + '*' }}  # [win]
 
   commands:
-    - test -f ${PREFIX}/lib/libyasm.a       # [unix]
+    - test -f ${PREFIX}/lib/libyasm.a              # [unix]
+    - if not exist %LIBRARY_LIB%\\yasm.lib exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\\yasm.dll exit 1  # [win]
     - vsyasm --help
     - yasm --help
     - ytasm /h


### PR DESCRIPTION
Fixes https://github.com/conda-forge/yasm-feedstock/issues/2

Attempts to build from source on Windows using `cmake`.